### PR TITLE
Store new fields outside of existing serialised data structures to avoid reparse

### DIFF
--- a/src/omnicore/dbspinfo.h
+++ b/src/omnicore/dbspinfo.h
@@ -100,7 +100,6 @@ public:
         template <typename Stream, typename Operation>
         inline void SerializationOp(Stream& s, Operation ser_action) {
             READWRITE(issuer);
-            READWRITE(delegate);
             READWRITE(prop_type);
             READWRITE(prev_prop_id);
             READWRITE(category);
@@ -125,7 +124,6 @@ public:
             READWRITE(manual);
             READWRITE(historicalData);
             READWRITE(historicalIssuers);
-            READWRITE(historicalDelegates);
         }
 
         bool isDivisible() const;

--- a/src/omnicore/dbspinfo.h
+++ b/src/omnicore/dbspinfo.h
@@ -123,7 +123,6 @@ public:
             READWRITE(update_block);
             READWRITE(fixed);
             READWRITE(manual);
-            READWRITE(unique);
             READWRITE(historicalData);
             READWRITE(historicalIssuers);
             READWRITE(historicalDelegates);

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -38,7 +38,7 @@ int const DONT_STORE_MAINNET_STATE_UNTIL = 622000;
 #define TEST_ECO_PROPERTY_1 (0x80000003UL)
 
 // increment this value to force a refresh of the state (similar to --startclean)
-#define DB_VERSION 10
+#define DB_VERSION 8
 
 // could probably also use: int64_t maxInt64 = std::numeric_limits<int64_t>::max();
 // maximum numeric values from the spec:

--- a/test/functional/omni_nonfungibletokens.py
+++ b/test/functional/omni_nonfungibletokens.py
@@ -60,6 +60,12 @@ class OmniNonFungibleTokensTest(BitcoinTestFramework):
         assert("Sender does not own the range" in errorString)
         errorString = ""
 
+        # Get property and check fields
+        result = self.nodes[0].omni_getproperty(property_id)
+        assert_equal(result['fixedissuance'], False)
+        assert_equal(result['managedissuance'], True)
+        assert_equal(result['non-fungibletoken'], True)
+
         # Checking the transaction was valid...
         result = self.nodes[0].omni_gettransaction(txid)
         assert_equal(result['valid'], True)


### PR DESCRIPTION
Rather than change serialisation in the existing CMPSPInfo which requires a full reparse of the database store the new fields separately and load into CMPSPInfo when required.